### PR TITLE
add remi

### DIFF
--- a/applications/app-markdowns/guis.md
+++ b/applications/app-markdowns/guis.md
@@ -20,6 +20,7 @@ GUI
 * [wxPython](http://wxpython.org/) - A blending of the wxWidgets C++ class library with the Python.
 * [PyGObject](https://wiki.gnome.org/Projects/PyGObject) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3)
 * [Flexx](https://github.com/zoofIO/flexx) - Flexx is a pure Python toolkit for creating GUI's, that uses web technology for its rendering.
+* [remi](https://github.com/dddomodossola/remi) - RemI is a GUI library for Python applications which transpiles an application's interface into HTML to be rendered in a web browser.
 
 Contributors
 ============


### PR DESCRIPTION
Python REMote Interface library. Platform independent.
RemI is a GUI library for Python applications which transpiles an application's interface into HTML to be rendered in a web browser. This removes platform-specific dependencies and lets you easily develop cross-platform applications in Python!